### PR TITLE
Added route for wish details, cleaned up wish details and childInfo, …

### DIFF
--- a/ui/src/app/App.js
+++ b/ui/src/app/App.js
@@ -6,6 +6,7 @@ import WishList from '../wishList'
 import WatchAuth from '../auth/WatchAuth'
 import ChildInfo from '../childinfo/ChildInfo'
 import CreateWish from '../landing/CreateWish'
+import WishDetails from '../wishDetails/WishDetails';
 
 function App() {
   return (
@@ -15,6 +16,7 @@ function App() {
           <Route exact path="/child-info" component={ChildInfo} />
           <Route exact path="/landing" component={CreateWish} />
           <Route exact path="/wish-summary" component={WishList} />
+          <Route exact path="/wish-summary/:id" component={WishDetails} />
           <Route exact path="/" component={Login} />
         </Switch>
       </WatchAuth>

--- a/ui/src/app/App.test.js
+++ b/ui/src/app/App.test.js
@@ -6,6 +6,7 @@ import Login from '../login/Login'
 import ChildInfo from '../childinfo/ChildInfo'
 import CreateWish from '../landing/CreateWish'
 import WishList from '../wishList'
+import WishDetails from '../wishDetails/WishDetails';
 
 describe('Default routing behavior', () => {
   it('renders the login page by default', () => {
@@ -13,11 +14,19 @@ describe('Default routing behavior', () => {
 
     let loginRoute = wrapper
       .find(Route)
-      .at(3)
+      .at(4)
       .props()
 
     expect(loginRoute.path).toEqual('/')
     expect(loginRoute.component).toEqual(Login)
+
+    let wishDetailsRoute = wrapper
+      .find(Route)
+      .at(3)
+      .props()
+
+    expect(wishDetailsRoute.path).toEqual('/wish-summary/:id')
+    expect(wishDetailsRoute.component).toEqual(WishDetails)
 
     let wishCurationRoute = wrapper
       .find(Route)

--- a/ui/src/childinfo/ChildInfo.js
+++ b/ui/src/childinfo/ChildInfo.js
@@ -1,5 +1,6 @@
 
 import React, { Component } from 'react';
+import WishDetailsService from '../services/WishDetailsService';
 import rocketImage from '../../src/assets/images/icn_To_Go_Rocket_White_Inside_130x130.png';
 import './ChildInfo.css';
 
@@ -59,8 +60,25 @@ export default class ChildInfo extends Component {
       });
     } else {
 
+      const { name, age, homeTown, illness, details } = this.state
+      const { type } = this.props
+
+      const wish = {
+        child: {
+          name: name,
+          age: age,
+          hometown: homeTown,
+          illness: illness
+        },
+        type: type ? type : '',
+        details: details
+      }
+
+      const response = await WishDetailsService.makeAWish(wish)
+
       this.setState({
-        showConfirmation: true
+        showConfirmation: true,
+        childId: response._id
       })
     }
   }

--- a/ui/src/childinfo/ChildInfo.js
+++ b/ui/src/childinfo/ChildInfo.js
@@ -1,7 +1,5 @@
 
 import React, { Component } from 'react';
-import WishDetailsService from '../services/WishDetailsService';
-import WishDetails from '../wishDetails/WishDetails';
 import rocketImage from '../../src/assets/images/icn_To_Go_Rocket_White_Inside_130x130.png';
 import './ChildInfo.css';
 
@@ -19,8 +17,7 @@ export default class ChildInfo extends Component {
       rocketRotation: 20,
       rocketWidth: 170,
       rocketContainerHeight: 350,
-      isBlastOff: false,
-      childId: undefined
+      isBlastOff: false
     }
     this.numSteps = Object.keys(this.stepMapFunction()).length
   }
@@ -62,25 +59,8 @@ export default class ChildInfo extends Component {
       });
     } else {
 
-      const { name, age, homeTown, illness, details } = this.state
-      const { type } = this.props
-
-      const wish = {
-        child: {
-          name: name,
-          age: age,
-          hometown: homeTown,
-          illness: illness
-        },
-        type: type ? type : '',
-        details: details
-      }
-
-      const response = await WishDetailsService.makeAWish(wish)
-
       this.setState({
-        showConfirmation: true,
-        childId: response._id
+        showConfirmation: true
       })
     }
   }
@@ -181,9 +161,8 @@ export default class ChildInfo extends Component {
 
   render() {
     let inputValue = this.state[this.getInputType()];
-    let { showConfirmation, showWishDetails, childId, isBlastOff, step } = this.state;
+    let { showConfirmation, isBlastOff, step } = this.state;
     return (
-      !showWishDetails ?
         <React.Fragment>
           {
             !showConfirmation ?
@@ -205,8 +184,7 @@ export default class ChildInfo extends Component {
                 {!isBlastOff && <button className='rocket-blast-off-button' onClick={this.rocketBlastOff}>Ready for blast off?</button>}
               </div>
           }
-        </React.Fragment> :
-        childId && <WishDetails childId={childId} />
+        </React.Fragment>
     )
   }
 }

--- a/ui/src/childinfo/ChildInfo.test.js
+++ b/ui/src/childinfo/ChildInfo.test.js
@@ -98,20 +98,6 @@ describe('Initial Render', () => {
     })
   })
 
-  describe('When `showWishDetails` in state is true and `childId` in state is defined', () => {
-    beforeEach(() => {
-      childInfo = shallow(<ChildInfo />);
-      childInfo.instance().setState({
-        showWishDetails: true,
-        childId: 'a child id'
-      })
-    })
-
-    it('Should show WishDetails component', () => {
-      expect(childInfo.find('WishDetails').length).toEqual(1)
-    })
-  })
-
   describe('When user on confirmation page and click blast off the rocket', () => {
 
     beforeEach(() => {

--- a/ui/src/landing/CreateWish.js
+++ b/ui/src/landing/CreateWish.js
@@ -18,7 +18,6 @@ export default class CreateWish extends Component {
   }
 
   selectWishType = (wishType) => {
-    console.log(wishType)
     this.setState({ wishType })
   }
 

--- a/ui/src/wishDetails/WishDetails.js
+++ b/ui/src/wishDetails/WishDetails.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import PropsType from 'prop-types'
+import { Link } from 'react-router-dom'
 import WishDetailsService from '../services/WishDetailsService'
 import Rocket from '../assets/images/icn_To_Go_Rocket_White_Inside_130x130.png'
 import Alien from '../assets/images/icn_To_Meet_Alien_White_Inside_130x130.png'
@@ -33,9 +33,10 @@ export default class WishDetails extends Component {
   }
 
   async componentDidMount() {
-    const wishDetails = await WishDetailsService.getWishDetails(this.props.childId)
+    const { id } = this.props.match.params
+    const wishDetails = await WishDetailsService.getWishDetails(id)
     wishDetails && wishDetails !== '' && this.setState({
-      wishDetails: wishDetails
+      wishDetails
     })
   }
 
@@ -63,15 +64,17 @@ export default class WishDetails extends Component {
 
   render() {
     const { child, details, sponsor } = this.state.wishDetails
+    const { name, age, hometown } = child;
+
     return (
       <div className='wishDetails containerVertical'>
-
+        <Link to="/wish-summary">Back to Summary</Link>
         <div className='containerHorizontal'>
           <div className='containerVertical'>
             <div className='childDetails'>
-              <p>Name</p>
-              <p>Age</p>
-              <p>Hometown</p>
+              <label>Name: </label><span>{name}</span>
+              <label>Age: </label><span>{age}</span>
+              <label>Hometown: </label><span>{hometown}</span>
             </div>
             <div className='illness-summary containerVertical'>
               <h3>Illness Summary</h3>
@@ -99,8 +102,4 @@ export default class WishDetails extends Component {
       </div>
     )
   }
-}
-
-WishDetails.propTypes = {
-  childId: PropsType.string.isRequired
 }

--- a/ui/src/wishDetails/WishDetails.test.js
+++ b/ui/src/wishDetails/WishDetails.test.js
@@ -59,7 +59,6 @@ describe('Initial Render', () => {
 
   it('renders!', () => {
     expect(wishInfo.exists('.wishInfo'));
-    expect(wishInfo.instance().state.wishDetails.child.name).toEqual('child name');
   })
 
   describe('Getting image for wish type', () => {

--- a/ui/src/wishList/index.js
+++ b/ui/src/wishList/index.js
@@ -21,12 +21,13 @@ export default class WishList extends Component {
   }
 
   filterWishes = (e) => {
+    //TODO
   }
 
   render() {
     const { wishes } = this.state
     const wishList = wishes.map(wish => {
-      return <Wish key={wish._id} wish={wish} />
+      return <Wish key={wish._id} wish={wish} history={this.props.history} />
     })
 
     return (

--- a/ui/src/wishList/wish/index.js
+++ b/ui/src/wishList/wish/index.js
@@ -4,17 +4,22 @@ import ImgPlaceholder from '../imgPlaceholder'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faChevronRight } from '@fortawesome/free-solid-svg-icons'
 
-const Wish = ({ wish }) => {
+const Wish = ({ wish, history }) => {
   const { child, sponsor, details } = wish
 
+  const handleWishClick = (id) => {
+    const url = `/wish-summary/${id}`;
+    history.push(url);
+  }
+
   return (
-    <li className="wish">
+    <li className="wish" onClick={() => handleWishClick(wish._id)}>
       <div className="date">
       </div>
       {child.image ? <img src={child.image} alt="child" /> : <ImgPlaceholder text="Add Image" />}
       <div>
         <p>
-          <strong>Maria</strong> - Age {child.age} from {child.hometown}
+          <strong>{child.name}</strong> - Age {child.age} from {child.hometown}
         </p>
         <span className="summary">
                         {details}

--- a/ui/src/wishList/wish/index.test.js
+++ b/ui/src/wishList/wish/index.test.js
@@ -25,3 +25,28 @@ describe('Wish tests', () => {
     expect(wrapper).toMatchSnapshot()
   })
 })
+
+describe('handle wish click', () => {
+  const wish = {
+    child: {
+      name: 'Jerel Weber',
+      age: 5,
+      hometown: 'North Robertside',
+      illness: 'SMTP'
+    },
+    sponsor: {
+      links: []
+    },
+    _id: '5d0528c11170183ea576e3da',
+    type: 'be',
+    details: 'overriding calculating Shirt',
+    __v: 0
+  }
+
+  it('should navigate user to wish Details page', () => {
+    const historyMock = { push: jest.fn() };
+    const wrapper = shallow(<Wish history={historyMock} wish={wish} />);
+    wrapper.find('li').simulate('click');
+    expect(historyMock.push.mock.calls[0]).toEqual([('/wish-summary/5d0528c11170183ea576e3da')]);
+  })
+});


### PR DESCRIPTION
Added route for wish details, cleaned up wish details and childInfo, added unit tests

### What was the feature/problem?

No route from Wish summary page to go to Wish Details.

### How does this PR address the above feature/problem?

Add route for WishDetails page and provide a link to navigate between wish summary and wish details pages

### Check lists (check `x` in `[ ]` of list items)

- [ x] Test passed
- [x ] Coding style (indentation, etc)

### Additional Comments (if any)

