### PR TITLE
fixed type to be lowercase

### DIFF
--- a/ui/src/childinfo/ChildInfo.js
+++ b/ui/src/childinfo/ChildInfo.js
@@ -74,7 +74,7 @@ export default class ChildInfo extends Component {
           hometown: homeTown,
           illness: illness
         },
-        type: type ? type : '',
+        type: type ? type.toLowerCase() : '',
         details: details
       }
 


### PR DESCRIPTION
<!-- Thank you for your contribution to the hackathon-starter! Please replace {Please write here} with your description -->

### What was the feature/problem?

Wish type enum (service side) was expecting lowercase type, UI was sending uppercase

### How does this PR address the above feature/problem?

UI is now sending lowercase type 
### Check lists (check `x` in `[ ]` of list items)

- [ ] Test passed
- [ ] Coding style (indentation, etc)

### Additional Comments (if any)

Related to this issue: https://github.com/homedepot/hackathon-purple-parrots/issues/29
